### PR TITLE
fix rendering of invalid_json template and remove rendundant file

### DIFF
--- a/src/to-html.js
+++ b/src/to-html.js
@@ -122,7 +122,9 @@ var partials = {
 };
 
 _.forEach(partials, function(v, k) {
-  var template = handlebars.template(handlebars.precompile(loadTemplate(v)));
+  // handlebars.compile works better and more simply than the
+  // handlebars.template function recommended in the docs.
+  var template = handlebars.compile(loadTemplate(v));
   handlebars.registerPartial(k, template);
 });
 

--- a/src/to-html.js
+++ b/src/to-html.js
@@ -80,7 +80,8 @@ handlebars.registerHelper('showCode', function(data, o) {
     try {
       data = prettyJson(JSON.parse(data));
     } catch (e) {
-      err = partials.jsonParseError;
+      console.error("invalid json: " + e);
+      err = handlebars.partials.jsonParseError({});
     }
     out = hljs.highlight('json', data);
     return new handlebars.SafeString(
@@ -117,11 +118,12 @@ var partials = {
   tableOfContents: 'table_of_contents.handlebars',
   style: 'style.css',
   parameters: 'parameters.handlebars',
-  jsonParseError: 'invalid_json.html',
+  jsonParseError: 'invalid_json.handlebars',
 };
 
 _.forEach(partials, function(v, k) {
-  handlebars.registerPartial(k, loadTemplate(v));
+  var template = handlebars.template(handlebars.precompile(loadTemplate(v)));
+  handlebars.registerPartial(k, template);
 });
 
 var toHtml = handlebars.compile(loadTemplate('index.handlebars'), {

--- a/templates/invalid_json.html
+++ b/templates/invalid_json.html
@@ -1,5 +1,0 @@
-<div class="alert alert-danger" role="alert">
-  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-  <span class="sr-only">Error:</span>
-  This JSON is not valid
-</div>


### PR DESCRIPTION
When encountering invalid json the output html would render the literal
text "invalid_json.html" instead of loading/rendering the file's
contents.  It seems like this problem was introduced at ac7708ce.

The fix, using `handlebars.partials.jsonParseError` instead of
`partials.jsonParseError` showed that not all partials were being
compiled as templates, some were strings and some were functions (i.e.
compiled templates).  Templates are now compiled explicity (edit: ~~according to the
[documentation](http://handlebarsjs.com/reference.html)~~).

The file invalid_json.html was identical to invalid_json.handlebars.  It
has been removed in favor of the template, consistent with making all
partials templates.