### PR TITLE
support the top-level "documentation" structure in raml documents

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,7 @@ function flattenHierarchy(root) {
     baseUri: root.baseUri,
     baseUriParameters: root.baseUriParameters,
     securitySchemes: securitySchemes,
+    documentation: root.documentation,
     title: root.title,
     traits: traits,
     version: root.version,

--- a/src/to-html.js
+++ b/src/to-html.js
@@ -113,6 +113,7 @@ handlebars.registerHelper('upperCase', _.method('toUpperCase'));
 var partials = {
   index: 'index.handlebars',
   resource: 'resource.handlebars',
+  documentation: 'documentation.handlebars',
   securityScheme: 'security_scheme.handlebars',
   tableOfContents: 'table_of_contents.handlebars',
   style: 'style.css',

--- a/templates/documentation.handlebars
+++ b/templates/documentation.handlebars
@@ -1,0 +1,8 @@
+<div class="card documentation">
+<h3 class="anchor" id="documentation-{{title}}">
+  <a href="#documentation-{{title}}">
+    {{title}}
+  </a>
+</h3>
+<div class="content">{{markdown content}}</div>
+</div>

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -19,6 +19,12 @@
   </div>
   <main>
     <h1 class="main-heading">{{title}}{{#if version}} {{version}}{{/if}} Documentation</h1>
+    {{#if documentation}}
+      <h2>Documentation</h2>
+      {{#each documentation}}
+        {{> documentation}}
+      {{/each}}
+    {{/if}}
     {{#if baseUri}}
       <h2>Base URI</h2>
       <div class="card api-metadata">

--- a/templates/table_of_contents.handlebars
+++ b/templates/table_of_contents.handlebars
@@ -1,4 +1,12 @@
 <ul class="nav nav-pills nav-stacked">
+  {{#each documentation}}
+    <li class="sidebar-item">
+      <a href="#documentation-{{title}}"
+         title="{{title}}">
+        <strong>{{title}}</strong>
+      </a>
+    </li>
+  {{/each}}
   {{#each resources}}
     {{#if path}}
       <li class="sidebar-item">


### PR DESCRIPTION
Documentation items are presented on individual cards.  Items are also
given a link in the side bar.

edit: See the [spec](http://raml.org/spec.html#user-documentation) for more information about the "documentation" structure.