### PR TITLE
Allow multiple response types.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -104,11 +104,7 @@ function flattenMethods(methods) {
       obj.method = objForMethod.method;
       obj.headers = objForCode.headers;
       obj.description = objForCode.description;
-      _.forEach(objForCode.body, function(objForRespType, respType) {
-        obj.type = respType;
-        obj.example = objForRespType.example;
-        obj.schema = objForRespType.schema;
-      });
+      obj.examples = makeExamplesOf(objForCode);
       return obj;
     });
     return obj;

--- a/templates/resource.handlebars
+++ b/templates/resource.handlebars
@@ -75,7 +75,7 @@
             {{/if}}
           </h5>
           {{showCode example type=type}}
-          {{/each}}
+        {{/each}}
       {{/if}}
     {{/each}}
   {{/if}}

--- a/templates/resource.handlebars
+++ b/templates/resource.handlebars
@@ -66,14 +66,16 @@
         <h5>Response JSON Schema</h5>
         {{showCode schema type="json"}}
       {{/if}}
-      {{#if example}}
-        <h5>
-          Response Example
-          {{#if type}}
-            (<tt>{{type}}</tt>)
-          {{/if}}
-        </h5>
-        {{showCode example type=type}}
+      {{#if examples}}
+        {{#each examples}}
+          <h5>
+            Response Example
+            {{#if type}}
+              (<tt>{{type}}</tt>)
+            {{/if}}
+          </h5>
+          {{showCode example type=type}}
+          {{/each}}
       {{/if}}
     {{/each}}
   {{/if}}


### PR DESCRIPTION
Used the existing `makeExamplesOf` function, seems this was the intent
all along.