### PR TITLE
Add table class to Markdown renderer

### DIFF
--- a/src/to-html.js
+++ b/src/to-html.js
@@ -107,7 +107,18 @@ handlebars.registerHelper('showCode', function(data, o) {
   }
 });
 handlebars.registerHelper('markdown', function(md) {
-  return md ? new handlebars.SafeString(marked(md)) : '';
+  var renderer = new marked.Renderer();
+  renderer.table = function(header, body) {
+    return '<table class="table">\n'
+      + '<thead>\n'
+      + header
+      + '</thead>\n'
+      + '<tbody>\n'
+      + body
+      + '</tbody>\n'
+      + '</table>\n';
+  };
+  return md ? new handlebars.SafeString(marked(md, { renderer: renderer })) : '';
 });
 handlebars.registerHelper('upperCase', _.method('toUpperCase'));
 


### PR DESCRIPTION
The default Markdown renderer doesn't include a "table" class, so tables
are not styled as expected.  Add a custom renderer that ensures that
tables have the proper class.