### PR TITLE
DOCS-1618 Added text stylings

### DIFF
--- a/templates/style.css
+++ b/templates/style.css
@@ -194,7 +194,27 @@ code {
 .method:last-child {
   border-bottom: none;
 }
-
+.text-muted {
+  color: #999385;
+}
+.text-primary {
+  color: #F05A27;
+}
+.text-secondary {
+  color: #22BBB8;
+}
+.text-success {
+  color: #346235;
+}
+.text-info {
+  color: #1A757D;
+}
+.text-warning {
+  color: #FFB82E;
+}
+.text-danger {
+  color: #CC3333;
+}
 @media only screen {
   #side-navbar {
     width: 200px;


### PR DESCRIPTION
I added classes to style the text. The colors were taken from [janrain-bootstrap](https://github.com/janrain/bootstrap). 

The following:
```
<p class="text-muted">Muted Text</p>
<p class="text-primary">Primary Text</p>
<p class="text-secondary">Secondary Text</p>
<p class="text-success">Success Text</p>
<p class="text-info">Info Text</p>
<p class="text-warning">Warning Text</p>
<p class="text-danger">Danger Text</p>
```
will now produce:
![screen shot 2016-02-26 at 9 33 42 am](https://cloud.githubusercontent.com/assets/16297132/13360133/8404dd8c-dc6c-11e5-86d1-8f31142221ac.png)