### PR TITLE
Added the `--bare` flag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "highlight.js": "^9.1.0",
     "lodash": "^3.9.3",
     "marked": "^0.3.3",
-    "raml-parser": "^0.8.11"
+    "raml-parser": "^0.8.11",
+    "yargs": "^3.32.0"
   },
   "scripts": {
     "travis": "jshint src/*.js && jscs src/*.js",

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,18 @@ var _ = require('lodash');
 var raml = require('raml-parser');
 var pkg = require('../package');
 var toHtml = require('./to-html').toHtml;
+const argv = require('yargs')
+  .usage('Usage: $0 [input] [options]')
+  .example('$0 myDocs.raml > myDocs.html')
+  .example('$0 myDocs.raml -b > myDocs.html')
+  .demand(1, 'RAML file required')
+  .option('bare', {
+    alias: 'b',
+    description: 'Omits top level HTML elements and styles if true.',
+    default: false
+  })
+  .argv;
+const input = argv._[0]
 
 var config = {
   version: pkg.version
@@ -111,13 +123,6 @@ function flattenMethods(methods) {
   });
 }
 
-// Grab input RAML filename.
-var args = process.argv.slice(2);
-if (args.length !== 1) {
-  die('Expected one argument: input RAML file');
-}
-var input = args[0];
-
 function write(x) {
   process.stdout.write(x);
 }
@@ -137,6 +142,6 @@ raml
   .then(function(obj) {
     return _.extend(obj, {config: config});
   })
-  .then(toHtml)
+  .then(toHtml(argv.bare))
   .then(write)
   .catch(throwLater);

--- a/src/to-html.js
+++ b/src/to-html.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('lodash');
 var path = require('path');
 var fs = require('fs');
@@ -134,6 +136,7 @@ handlebars.registerHelper('upperCase', _.method('toUpperCase'));
 
 var partials = {
   index: 'index.handlebars',
+  main: 'main.handlebars',
   resource: 'resource.handlebars',
   documentation: 'documentation.handlebars',
   securityScheme: 'security_scheme.handlebars',
@@ -146,13 +149,13 @@ var partials = {
 _.forEach(partials, function(v, k) {
   // handlebars.compile works better and more simply than the
   // handlebars.template function recommended in the docs.
-  var template = handlebars.compile(loadTemplate(v));
+  var template = handlebars.compile(loadTemplate(v), { preventIndent: true });
   handlebars.registerPartial(k, template);
 });
 
-var toHtml = handlebars.compile(loadTemplate('index.handlebars'), {
-  preventIndent: true
-});
+let toHtml = (bare) => {
+  return bare ? handlebars.partials.main : handlebars.partials.index
+}
 
 module.exports = {
   toHtml: toHtml

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -13,38 +13,6 @@
   </style>
 </head>
 <body>
-  <div id="side-navbar">
-    {{> tableOfContents}}
-  </div>
-  <main>
-    <h1 class="main-heading">{{title}}{{#if version}} {{version}}{{/if}} Documentation</h1>
-    {{#if documentation}}
-      <h2>Documentation</h2>
-      {{#each documentation}}
-        {{> documentation}}
-      {{/each}}
-    {{/if}}
-    {{#if baseUri}}
-      <h2>Base URI</h2>
-      <div class="card api-metadata">
-        <h3>{{baseUri}}</h3>
-        {{#if baseUriParameters}}
-          {{> parameters type="URI Parameters" params=baseUriParameters}}
-        {{/if}}
-      </div>
-    {{/if}}
-    {{#if securitySchemes}}
-      <h2>Security Schemes</h2>
-      {{#each securitySchemes}}
-        {{> securityScheme}}
-      {{/each}}
-    {{/if}}
-    <h2>Endpoints</h2>
-    {{#each resources}}
-      {{#if path}}
-        {{> resource}}
-      {{/if}}
-    {{/each}}
-  </main>
+  {{> main}}
 </body>
 </html>

--- a/templates/main.handlebars
+++ b/templates/main.handlebars
@@ -1,0 +1,33 @@
+<div id="side-navbar">
+  {{> tableOfContents}}
+</div>
+<main>
+  <h1 class="main-heading">{{title}}{{#if version}} {{version}}{{/if}} Documentation</h1>
+  {{#if documentation}}
+    <h2>Documentation</h2>
+    {{#each documentation}}
+      {{> documentation}}
+    {{/each}}
+  {{/if}}
+  {{#if baseUri}}
+    <h2>Base URI</h2>
+    <div class="card api-metadata">
+      <h3>{{baseUri}}</h3>
+      {{#if baseUriParameters}}
+        {{> parameters type="URI Parameters" params=baseUriParameters}}
+      {{/if}}
+    </div>
+  {{/if}}
+  {{#if securitySchemes}}
+    <h2>Security Schemes</h2>
+    {{#each securitySchemes}}
+      {{> securityScheme}}
+    {{/each}}
+  {{/if}}
+  <h2>Endpoints</h2>
+  {{#each resources}}
+    {{#if path}}
+      {{> resource}}
+    {{/if}}
+  {{/each}}
+</main>


### PR DESCRIPTION
Now raml-fleece can output just the bare HTML (i.e. without any styles
or top level html tags). This allows the output to be easily
included/imported into other projects.