### PR TITLE
Code highlighting is now more automatic.

### DIFF
--- a/templates/invalid_json.handlebars
+++ b/templates/invalid_json.handlebars
@@ -1,5 +1,0 @@
-<div class="alert alert-danger" role="alert">
-  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-  <span class="sr-only">Error:</span>
-  This JSON is not valid
-</div>

--- a/templates/parameters.handlebars
+++ b/templates/parameters.handlebars
@@ -1,6 +1,5 @@
 <div class="params">
   <h4>{{type}}</h4>
-  {{!-- {{json .}} --}}
   <dl>
   {{#each params}}
     <dt>


### PR DESCRIPTION
Added a "blacklist" of content types that should not have
highlighting applied, currently only `text/plain`. This may become
configurable in the future.
Also removed the JSON parse error template, this can be handled by a
tool other than raml-fleece.