### PR TITLE
DOCS-1688 Remove documentation header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-fleece",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "bin": "./src/main.js",
   "repository": "janrain/raml-fleece",

--- a/templates/main.handlebars
+++ b/templates/main.handlebars
@@ -4,7 +4,6 @@
 <div id="fleece-content" class="fleece-content">
   <h1 class="main-heading">{{title}}{{#if version}} {{version}}{{/if}} Documentation</h1>
   {{#if documentation}}
-    <h2>Documentation</h2>
     {{#each documentation}}
       {{> documentation}}
     {{/each}}


### PR DESCRIPTION
Renders the docs project as the following:

![screen shot 2016-04-29 at 9 39 53 am](https://cloud.githubusercontent.com/assets/16297132/14923250/060ae8b6-0df1-11e6-89d2-48a1c47462d5.png)
![screen shot 2016-04-29 at 9 39 48 am](https://cloud.githubusercontent.com/assets/16297132/14923249/060adb1e-0df1-11e6-8013-acca50d17cea.png)
