### PR TITLE
DIP-311 custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ _raml-fleece_ turns [RAML](http://raml.org) into a readable HTML file. It curren
 
     raml-fleece api.raml > index.html
 
+# Custom Templates and Scripts
+
+Custom Templates and scripts let you overwrite and extend the templates and scripts. See the command line help for details.
+
 # Thanks
 
 This tool was originally built using [raml2html](https://github.com/kevinrenskers/raml2html).

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "handlebars": "^4.0.5",
     "highlight.js": "^9.1.0",
     "less": "^2.6.1",
-    "lodash": "^3.9.3",
+    "lodash": "^4.13.1",
     "marked": "^0.3.3",
     "raml-parser": "^0.8.11",
-    "yargs": "^3.32.0"
+    "yargs": "^4.7.1"
   },
   "scripts": {
     "travis": "jshint src/*.js && jscs src/*.js",

--- a/src/cmdline.js
+++ b/src/cmdline.js
@@ -1,0 +1,110 @@
+const argv = require('yargs')
+  .usage('Usage: $0 [input] [options]')
+  .example('$0 myDocs.raml > myDocs.html')
+  .example('$0 myDocs.raml -b > myDocs.html')
+  .demand(1, 'RAML file required')
+  .group([
+      'bare',
+      'postmanId',
+    ],
+    'Options:'
+  )
+  .option('bare', {
+    alias: 'b',
+    description: 'Omits top level HTML elements and styles if true.',
+    default: false
+  })
+  .option('postmanId', {
+    alias: 'p',
+    description: 'Add Postman Collection ID',
+    default: false
+  })
+  .group([
+      'template-documentation',
+      'template-index',
+      'template-before-main',
+      'template-main',
+      'template-after-main',
+      'template-parameters',
+      'template-resource',
+      'template-securityScheme',
+      'template-tableOfContents',
+      'template-after-tableOfContents',
+    ],
+    'Custom Templates:'
+  )
+  .option('template-documentation', {
+    description: 'Path to custom documentation template (overwrites)',
+    type: 'string',
+    normalize: true
+  })
+  .option('template-index', {
+    description: 'path to custom index template (overwrites)',
+    type: 'string',
+    normalize: true
+  })
+  .option('template-before-main', {
+    description: 'path to custom before main template',
+    type: 'string',
+    normalize: true
+  })
+  .option('template-main', {
+    description: 'path to custom main template (overwrites)',
+    type: 'string',
+    normalize: true
+  })
+  .option('template-after-main', {
+    description: 'path to custom after main template',
+    type: 'string',
+    normalize: true
+  })
+  .option('template-parameters', {
+    description: 'path to custom parameters template (overwrites)',
+    type: 'string',
+    normalize: true
+  })
+  .option('template-resource', {
+    description: 'path to custom resource template (overwrites)',
+    type: 'string',
+    normalize: true
+  })
+  .option('template-securityScheme', {
+    description: 'path to custom security scheme template (overwrites)',
+    type: 'string',
+    normalize: true
+  })
+  .option('template-tableOfContents', {
+    description: 'path to custom table of contents template (overwrites)',
+    type: 'string',
+    normalize: true
+  })
+  .option('template-after-tableOfContents', {
+    description: 'path to custom after table of contents template',
+    type: 'string',
+    normalize: true
+  })
+  .group([
+      'before-style',
+      'style',
+      'after-style',
+    ],
+    'Custom Styles:'
+  )
+  .option('style', {
+    description: 'Custom style sheet (LESS) (overwrites)',
+    type: 'string',
+    normalize: true
+  })
+  .option('before-style', {
+    description: 'Custom before style sheet (LESS)',
+    type: 'string',
+    normalize: true
+  })
+  .option('after-style', {
+    description: 'Custom after style sheet (LESS)',
+    type: 'string',
+    normalize: true
+  })
+  .argv;
+
+module.exports.argv = argv

--- a/src/main.js
+++ b/src/main.js
@@ -91,7 +91,7 @@ function flattenResources(res, traits) {
     var clean = _.extend({}, res);
     delete clean.resources;
     clean.methods = flattenMethods(res.methods);
-    clean.basePath = _.pluck(parents, 'relativeUri').join('');
+    clean.basePath = _.map(parents, 'relativeUri').join('');
     clean.path = res.relativeUri;
     clean.fullPath = clean.basePath + clean.path;
     clean.pathId = makeSafeIdString(clean.fullPath)

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -11,10 +11,16 @@
   <script type="text/javascript"></script>
 
   <style>
-{{> style }}
+  {{#> custom-before-style}}{{/ custom-before-style}}
+  {{#> custom-style }}
+    {{> style }}
+  {{/ custom-style }}
+  {{#> custom-after-style}}{{/ custom-after-style}}
   </style>
 </head>
 <body>
-  {{> main}}
+  {{#> custom-main}}
+    {{> main}}
+  {{/ custom-main}}
 </body>
 </html>

--- a/templates/main.handlebars
+++ b/templates/main.handlebars
@@ -1,19 +1,27 @@
+{{#> custom-before-main}}{{/ custom-before-main}}
 <div id="fleece-table-of-contents" class="fleece-table-of-contents hidden-xs">
-  {{> tableOfContents}}
+  {{#> custom-tableOfContents}}
+    {{> tableOfContents}}
+  {{/ custom-tableOfContents}}
 </div>
+{{#> custom-after-tableOfContents}}{{/ custom-after-tableOfContents}}
 <div id="fleece-content" class="fleece-content">
   <h1 class="main-heading">{{title}}{{#if version}} {{version}}{{/if}} Documentation</h1>
   {{ postmanButton }}
   {{#if documentation}}
     {{#each documentation}}
-      {{> documentation}}
+      {{#> custom-documentation}}
+        {{> documentation}}
+      {{/ custom-documentation}}
     {{/each}}
   {{/if}}
   {{#if securitySchemes}}
     <section class="security-schemes">
       <h1 class="anchor" id="security-schemes"><a href="#security-schemes">Security Schemes</a></h1>
       {{#each securitySchemes}}
-        {{> securityScheme}}
+        {{#> custom-securityScheme}}
+          {{> securityScheme}}
+        {{/ custom-securityScheme}}
       {{/each}}
     </section>
   {{/if}}
@@ -24,14 +32,19 @@
       {{#if baseUriParameters}}
         <div class="params">
           <h2>URI Parameters</h2>
-          {{> parameters type="URI Parameters" params=baseUriParameters}}
+          {{#> custom-parameters type="URI Parameters" params=baseUriParameters}}
+            {{> parameters type="URI Parameters" params=baseUriParameters}}
+          {{/ custom-parameters}}
         </div>
       {{/if}}
     </section>
   {{/if}}
   {{#each resources}}
     {{#if path}}
-      {{> resource}}
+      {{#> custom-resource}}
+        {{> resource}}
+      {{/ custom-resource}}
     {{/if}}
   {{/each}}
 </div>
+{{#> custom-after-main}}{{/ custom-after-main}}

--- a/templates/resource.handlebars
+++ b/templates/resource.handlebars
@@ -11,7 +11,9 @@
 {{#if uriParameters}}
   <div class="params">
     <h2>URI Parameters</h2>
-    {{> parameters params=uriParameters}}
+    {{#> custom-parameters params=uriParameters}}
+      {{> parameters params=uriParameters}}
+    {{/ custom-parameters}}
   </div>
 {{/if}}
 {{#each methods}}
@@ -42,13 +44,17 @@
   {{#if headers}}
     <div class="params">
       <h3>Request Headers</h3>
-      {{> parameters params=headers}}
+      {{#> custom-parameters params=headers}}
+        {{> parameters params=headers}}
+      {{/ custom-parameters}}
     </div>
   {{/if}}
   {{#if queryParameters}}
     <div class="params">
       <h3>Query Parameters</h3>
-      {{> parameters params=queryParameters}}
+      {{#> custom-parameters params=queryParameters}}
+        {{> parameters params=queryParameters}}
+      {{/ custom-parameters}}
     </div>
   {{/if}}
   {{#each body}}
@@ -76,7 +82,9 @@
       {{#if headers}}
         <div class="params">
           <h4>Response Headers</h4>
-          {{> parameters params=headers}}
+          {{#> custom-parameters params=headers}}
+            {{> parameters params=headers}}
+          {{/ custom-parameters }}
         </div>
       {{/if}}
       {{#if schema}}

--- a/templates/security_scheme.handlebars
+++ b/templates/security_scheme.handlebars
@@ -13,10 +13,14 @@
   <p>{{markdown description}}</p>
   {{#with describedBy}}
     {{#if headers}}
-      {{> parameters type="Headers" params=headers}}
+      {{#> custom-parameters type="Headers" params=headers}}
+        {{> parameters type="Headers" params=headers}}
+      {{/ custom-parameters}}
     {{/if}}
     {{#if queryParameters}}
-      {{> parameters type="Query Parameters" params=queryParameters}}
+      {{#> custom-parameters type="Query Parameters" params=queryParameters}}
+        {{> parameters type="Query Parameters" params=queryParameters}}
+      {{/ custom-parameters}}
     {{/if}}
     <h3>Responses</h3>
     {{#each responses}}


### PR DESCRIPTION
```
$ ./src/main.js
Usage: src/main.js [input] [options]

Options:
  --bare, -b       Omits top level HTML elements and styles if true.
                                                                [default: false]
  --postmanId, -p  Add Postman Collection ID                    [default: false]

Custom Templates:
  --template-documentation    Path to custom documentation template (overwrites)
                                                                        [string]
  --template-index            path to custom index template (overwrites)[string]
  --template-before-main      path to custom before main template       [string]
  --template-main             path to custom main template (overwrites) [string]
  --template-after-main       path to custom after main template        [string]
  --template-parameters       path to custom parameters template (overwrites)
                                                                        [string]
  --template-resource         path to custom resource template (overwrites)
                                                                        [string]
  --template-securityScheme   path to custom security scheme template
                              (overwrites)                              [string]
  --template-tableOfContents  path to custom table of contents template
                              (overwrites)                              [string]

Custom Styles:
  --before-style  Custom before style sheet (LESS)                      [string]
  --style         Custom style sheet (LESS) (overwrites)                [string]
  --after-style   Custom after style sheet (LESS)                       [string]

Examples:
  src/main.js myDocs.raml > myDocs.html
  src/main.js myDocs.raml -b > myDocs.html

RAML file required
```