### PR TITLE
show maximum, minimum, and default queryParameters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,8 +4,6 @@
 // TODO: Show headers.
 // TODO: Show HTTPS.
 // TODO: Show OAuth.
-// TODO: Show query parameter enums.
-// TODO: Show query parameter default values.
 
 var _ = require('lodash');
 var raml = require('raml-parser');

--- a/templates/parameters.handlebars
+++ b/templates/parameters.handlebars
@@ -17,9 +17,21 @@
       {{/each}}
       </ul>
     {{/if}}
+    {{#if minimum}}
+      <b>Minimum: </b>
+      <code>{{minimum}}</code>
+    {{/if}}
+    {{#if maximum}}
+      <b>Maximum: </b>
+      <code>{{maximum}}</code>
+    {{/if}}
     {{#if example}}
       <b>Example: </b>
       <code>{{example}}</code>
+    {{/if}}
+    {{#if default}}
+      <b>Default: </b>
+      <code>{{default}}</code>
     {{/if}}
   </dd>
 {{/each}}


### PR DESCRIPTION
I just thought I would try this, and it seems to work. The max, min, default, and example values all show on the same line, which is fine by me, but I'm not a UI guy 😛 